### PR TITLE
Added option to select audio source

### DIFF
--- a/SWYH/Audio/WasapiProvider.cs
+++ b/SWYH/Audio/WasapiProvider.cs
@@ -62,11 +62,13 @@ namespace SWYH.Audio
             string captureDeviceID = SWYH.Properties.Settings.Default.AudioDevice;
             if (captureDeviceID != "")
             {
-                try
+                foreach (var wasapi in enumerator.EnumerateAudioEndPoints(DataFlow.All, DeviceState.Active))
                 {
-                    captureDevice = enumerator.GetDevice(captureDeviceID);
+                    if (wasapi.ID == captureDeviceID)
+                    {
+                        captureDevice = wasapi;
+                    }
                 }
-                catch { }
             }
             if (captureDevice == null)
             {

--- a/SWYH/Audio/WasapiProvider.cs
+++ b/SWYH/Audio/WasapiProvider.cs
@@ -25,6 +25,7 @@ namespace SWYH.Audio
 {
     using NAudio.Lame;
     using NAudio.Wave;
+    using NAudio.CoreAudioApi;
     using System;
     using System.Threading;
 
@@ -36,7 +37,7 @@ namespace SWYH.Audio
         private bool hasMP3Clients = false;
         private bool hasPCMClients = false;
 
-        private WasapiLoopbackCapture loopbackWaveIn = null;
+        private WasapiCapture loopbackWaveIn = null;
         private PipeStream recordingStream = null;
         private WaveStream rawConvertedStream = null;
         private WaveStream pcmStream = null;
@@ -55,8 +56,32 @@ namespace SWYH.Audio
             // Init Wave Processor thread
             Thread waveProcessorThread = new Thread(new ThreadStart(this.waveProcessor)) { Priority = ThreadPriority.Highest };
 
+            // Init capture audio device
+            MMDevice captureDevice = null;
+            var enumerator = new MMDeviceEnumerator();
+            string captureDeviceID = SWYH.Properties.Settings.Default.AudioDevice;
+            if (captureDeviceID != "")
+            {
+                try
+                {
+                    captureDevice = enumerator.GetDevice(captureDeviceID);
+                }
+                catch { }
+            }
+            if (captureDevice == null)
+            {
+                captureDevice = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+            }
+
             // Init Wasapi Capture
-            this.loopbackWaveIn = new WasapiLoopbackCapture();
+            if (captureDevice.DataFlow == DataFlow.Render)
+            {
+                this.loopbackWaveIn = new WasapiLoopbackCapture(captureDevice);
+            }
+            else
+            {
+                this.loopbackWaveIn = new WasapiCapture(captureDevice);
+            }
             this.loopbackWaveIn.DataAvailable += new EventHandler<WaveInEventArgs>(this.loopbackWaveIn_DataAvailable);
             
             // Init Raw Wav (16bit)

--- a/SWYH/Properties/Settings.Designer.cs
+++ b/SWYH/Properties/Settings.Designer.cs
@@ -73,6 +73,18 @@ namespace SWYH.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string AudioDevice {
+            get {
+                return ((string)(this["AudioDevice"]));
+            }
+            set {
+                this["AudioDevice"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool Debug {
             get {

--- a/SWYH/Properties/Settings.settings
+++ b/SWYH/Properties/Settings.settings
@@ -14,6 +14,9 @@
     <Setting Name="HTTPPort" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">0</Value>
     </Setting>
+    <Setting Name="AudioDevice" Type="System.String" Scope="User">
+      <Value Profile="(Default)"></Value>
+    </Setting>
     <Setting Name="Debug" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>

--- a/SWYH/Windows/SettingsWindow.xaml
+++ b/SWYH/Windows/SettingsWindow.xaml
@@ -1,21 +1,21 @@
 ﻿<Window x:Class="SWYH.SettingsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Stream What You Hear - Sebastien.warin.fr" Height="383" Width="432" Icon="/SWYH;component/Resources/Icons/swyh48.ico" 
+        Title="Stream What You Hear - Sebastien.warin.fr" Height="428" Width="432" Icon="/SWYH;component/Resources/Icons/swyh48.ico" 
         Loaded="Window_Loaded" WindowState="Normal" WindowStartupLocation="CenterScreen" ResizeMode="NoResize" Closing="Window_Closing" Topmost="True" KeyDown="Window_KeyDown">
     <Grid>
-        <TextBlock Margin="144,12,12,0" TextWrapping="Wrap" FontFamily="Showcard Gothic" TextAlignment="Center" Height="43" VerticalAlignment="Top"><Run FontSize="21.333" FontFamily="Segoe WP Black" Text="Settings"/></TextBlock>
+        <TextBlock Margin="144,12,12,0" TextWrapping="Wrap" FontFamily="Showcard Gothic" TextAlignment="Center" Height="27" VerticalAlignment="Top"><Run FontSize="21.333" FontFamily="Segoe WP Black" Text="Settings"/></TextBlock>
         <Image HorizontalAlignment="Left" Margin="12,12,0,0" Source="../Resources/Icons/swyh128.png" Stretch="Fill" Width="128" Height="128" VerticalAlignment="Top"/>
-        <Button x:Name="btValid" Content="OK" Height="23" HorizontalAlignment="Left" Margin="172,322,0,0" VerticalAlignment="Top" Width="75" Click="btValid_Click" />
-        <Button x:Name="btCancel" Content="Cancel" Height="23" HorizontalAlignment="Left" Margin="329,322,0,0" VerticalAlignment="Top" Width="75" Click="btCancel_Click" />
-        <GroupBox Header="Stream To" Height="75" HorizontalAlignment="Left" Margin="149,53,0,0" Name="groupBox1" VerticalAlignment="Top" Width="261">
+        <Button x:Name="btValid" Content="OK" Height="23" HorizontalAlignment="Left" Margin="172,367,0,0" VerticalAlignment="Top" Width="75" Click="btValid_Click" />
+        <Button x:Name="btCancel" Content="Cancel" Height="23" HorizontalAlignment="Left" Margin="329,367,0,0" VerticalAlignment="Top" Width="75" Click="btCancel_Click" />
+        <GroupBox Header="Stream To" Height="75" HorizontalAlignment="Left" Margin="149,40,0,0" Name="groupBox1" VerticalAlignment="Top" Width="261">
             <Grid>
                 <RadioButton Content="MP3" Height="16" HorizontalAlignment="Left" Margin="38,30,0,0" Name="radioButton1" GroupName="StreamFormat" VerticalAlignment="Top" />
                 <RadioButton Content="PCM/L16" Height="16" HorizontalAlignment="Left" Margin="152,30,0,0" Name="radioButton2" GroupName="StreamFormat" VerticalAlignment="Top" />
                 <Label Content="Send stream to DLNA device using :" HorizontalAlignment="Left" Margin="6,0,0,0" Name="label1" Height="28" VerticalAlignment="Top" />
             </Grid>
         </GroupBox>
-        <GroupBox Header="Format" Height="92" HorizontalAlignment="Left" Margin="149,128,0,0" Name="groupBox2" VerticalAlignment="Top" Width="261">
+        <GroupBox Header="Format" Height="92" HorizontalAlignment="Left" Margin="149,115,0,0" Name="groupBox2" VerticalAlignment="Top" Width="261">
             <Grid>
                 <Label Content="Capture :" Height="28" HorizontalAlignment="Left" Margin="6,6,0,0" Name="label2" VerticalAlignment="Top" />
                 <ComboBox Height="23" HorizontalAlignment="Left" Margin="70,6,0,0" Name="comboBox1" VerticalAlignment="Top" Width="173" />
@@ -23,7 +23,27 @@
                 <ComboBox Height="23" HorizontalAlignment="Left" Margin="160,40,0,0" Name="comboBox2" VerticalAlignment="Top" Width="83"  />
             </Grid>
         </GroupBox>
-        <GroupBox Header="General" Height="95" HorizontalAlignment="Left" Margin="149,220,0,0" Name="groupBox3" VerticalAlignment="Top" Width="261">
+        <GroupBox Header="Audio source" Height="58" HorizontalAlignment="Left" Margin="149,207,0,0" Name="groupBoxDevice" VerticalAlignment="Top" Width="261">
+            <Grid>
+                <ComboBox Height="23" HorizontalAlignment="Left" Margin="12,6,0,0" Name="comboBoxDevice" VerticalAlignment="Top" Width="231" SelectedValuePath="ID">
+                    <ComboBox.GroupStyle>
+                        <GroupStyle>
+                            <GroupStyle.HeaderTemplate>
+                                <DataTemplate>
+                                    <TextBlock FontWeight="Bold" Text="{Binding Name}"/>
+                                </DataTemplate>
+                            </GroupStyle.HeaderTemplate>
+                        </GroupStyle>
+                    </ComboBox.GroupStyle>
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Name}"/>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+            </Grid>
+        </GroupBox>
+        <GroupBox Header="General" Height="95" HorizontalAlignment="Left" Margin="149,265,0,0" Name="groupBox3" VerticalAlignment="Top" Width="261">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="228*" />

--- a/SWYH/Windows/SettingsWindow.xaml.cs
+++ b/SWYH/Windows/SettingsWindow.xaml.cs
@@ -28,12 +28,22 @@ namespace SWYH
     using System.Diagnostics;
     using System.Text.RegularExpressions;
     using System.Windows;
+    using System.Collections.Generic;
+    using System.Windows.Data;
+    using NAudio.CoreAudioApi;
 
     /// <summary>
     /// TODO : refactor this code with WPF style ;)
     /// </summary>
     public partial class SettingsWindow : Window
     {
+        class GroupItem
+        {
+            public string ID { get; set; }
+            public string Name { get; set; }
+            public string Category { get; set; }
+        }
+
         public SettingsWindow()
         {
             InitializeComponent();
@@ -54,9 +64,20 @@ namespace SWYH
             {
                 this.comboBox2.Items.Add(bitrate);
             }
+            List<GroupItem> deviceItems = new List<GroupItem>();
+            deviceItems.Add(new GroupItem() { ID = "", Name = "Default", Category = "" });
+            var enumerator = new MMDeviceEnumerator();
+            foreach (var wasapi in enumerator.EnumerateAudioEndPoints(DataFlow.All, DeviceState.Active))
+            {
+                deviceItems.Add(new GroupItem() { ID = wasapi.ID, Name = wasapi.FriendlyName, Category = wasapi.DataFlow.ToString() + " devices" });
+            }
+            ListCollectionView deviceItemsView = new ListCollectionView(deviceItems);
+            deviceItemsView.GroupDescriptions.Add(new PropertyGroupDescription("Category"));
+            this.comboBoxDevice.ItemsSource = deviceItemsView;
             // Select setting values
             this.comboBox1.SelectedItem = Audio.AudioFormats.AsString(Audio.AudioSettings.GetAudioFormat());
             this.comboBox2.SelectedItem = Audio.AudioSettings.GetMP3Bitrate();
+            this.comboBoxDevice.SelectedValue = SWYH.Properties.Settings.Default.AudioDevice;
             this.radioButton1.IsChecked = (Audio.AudioSettings.GetStreamFormat() == Audio.AudioFormats.Format.Mp3);
             this.radioButton2.IsChecked = !this.radioButton1.IsChecked;
             this.cbDebug.IsChecked = SWYH.Properties.Settings.Default.Debug;
@@ -78,6 +99,7 @@ namespace SWYH
             this.RegisterInStartup(this.cbRunAtWindowsStartup.IsChecked.Value);
             if (this.comboBox1.SelectedItem.ToString() == Audio.AudioFormats.AsString(Audio.AudioSettings.GetAudioFormat()) &&
                 this.comboBox2.SelectedItem.ToString() == Audio.AudioSettings.GetMP3Bitrate().ToString() &&
+                this.comboBoxDevice.SelectedValue.ToString() == SWYH.Properties.Settings.Default.AudioDevice &&
                 ((this.radioButton1.IsChecked.Value && Audio.AudioSettings.GetStreamFormat() == Audio.AudioFormats.Format.Mp3) ||
                  (this.radioButton2.IsChecked.Value && Audio.AudioSettings.GetStreamFormat() == Audio.AudioFormats.Format.Pcm)) &&
                 this.cbDebug.IsChecked == SWYH.Properties.Settings.Default.Debug &&
@@ -117,6 +139,7 @@ namespace SWYH
                     }
                     Audio.AudioSettings.SetMP3Bitrate(int.Parse(this.comboBox2.SelectedItem.ToString()));
                     Audio.AudioSettings.SetStreamFormat(this.radioButton1.IsChecked.Value ? Audio.AudioFormats.Format.Mp3 : Audio.AudioFormats.Format.Pcm);
+                    SWYH.Properties.Settings.Default.AudioDevice = this.comboBoxDevice.SelectedValue.ToString();
                     SWYH.Properties.Settings.Default.HTTPPort = (this.cbUseSpecificPort.IsChecked.HasValue && this.cbUseSpecificPort.IsChecked.Value) ? Int32.Parse(this.textBox1.Text) : 0;
                     SWYH.Properties.Settings.Default.Debug = this.cbDebug.IsChecked.HasValue && this.cbDebug.IsChecked.Value;
                     // Save !

--- a/SWYH/app.config
+++ b/SWYH/app.config
@@ -22,6 +22,9 @@
       <setting name="HTTPPort" serializeAs="String">
         <value>0</value>
       </setting>
+      <setting name="AudioDevice" serializeAs="String">
+        <value></value>
+      </setting>
       <setting name="Debug" serializeAs="String">
         <value>True</value>
       </setting>


### PR DESCRIPTION
Hi!
Now user can select default or any render (output) or any capture (input) audio device on settings window.
- Render (output) devices working as well through WasapiLoopbackCapture.
- Capture (input) devices working through WasapiCapture (parent class of WasapiLoopbackCapture).

I did test both of this types. Working good.
