### PR TITLE
Volume control

### DIFF
--- a/SWYH/App.xaml.cs
+++ b/SWYH/App.xaml.cs
@@ -56,6 +56,7 @@ namespace SWYH
         private AboutWindow aboutWindow = null;
         private HTTPLiveStreamWindow httpWindow = null;
         private RecordWindow recordWindow = null;
+        private VolumeWindow volumeWindow = null;
         private System.Windows.Forms.NotifyIcon notifyIcon = null;
         private System.Windows.Forms.ToolStripMenuItem streamToMenu = null;
         private System.Windows.Forms.ToolStripMenuItem searchingItem = null;
@@ -121,6 +122,7 @@ namespace SWYH
             this.aboutWindow = new AboutWindow();
             this.httpWindow = new HTTPLiveStreamWindow();
             this.recordWindow = new RecordWindow();
+            this.volumeWindow = new VolumeWindow();
             this.notifyIcon = new System.Windows.Forms.NotifyIcon()
             {
                 Icon = SWYH.Properties.Resources.swyh32,
@@ -143,6 +145,15 @@ namespace SWYH
             this.notifyIcon.ContextMenuStrip.Items.Add("About", null, (s, e2) => this.aboutWindow.Show());
             this.notifyIcon.ContextMenuStrip.Items.Add("-");
             this.notifyIcon.ContextMenuStrip.Items.Add("Exit", null, (s, e2) => this.Shutdown());
+            this.notifyIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(NotifyIcon_Click);
+        }
+
+        private void NotifyIcon_Click(object sender, System.Windows.Forms.MouseEventArgs e)
+        {
+            if (e.Button == System.Windows.Forms.MouseButtons.Left)
+            {
+                this.volumeWindow.ShowWithPosition();
+            }
         }
 
         private void CheckAutomaticDeviceStreamed(StartupEventArgs startupEvent)

--- a/SWYH/Audio/WasapiProvider.cs
+++ b/SWYH/Audio/WasapiProvider.cs
@@ -39,6 +39,7 @@ namespace SWYH.Audio
 
         private WasapiCapture loopbackWaveIn = null;
         private PipeStream recordingStream = null;
+        private Wave32To16Stream rawWave16b = null;
         private WaveStream rawConvertedStream = null;
         private WaveStream pcmStream = null;
         private LameMP3FileWriter mp3Writer = null;
@@ -85,9 +86,10 @@ namespace SWYH.Audio
                 this.loopbackWaveIn = new WasapiCapture(captureDevice);
             }
             this.loopbackWaveIn.DataAvailable += new EventHandler<WaveInEventArgs>(this.loopbackWaveIn_DataAvailable);
-            
+
             // Init Raw Wav (16bit)
-            WaveStream rawWave16b = new Wave32To16Stream(new RawSourceWaveStream(this.recordingStream, NAudio.Wave.WaveFormat.CreateIeeeFloatWaveFormat(this.loopbackWaveIn.WaveFormat.SampleRate, this.loopbackWaveIn.WaveFormat.Channels)));
+            this.rawWave16b = new Wave32To16Stream(new RawSourceWaveStream(this.recordingStream, NAudio.Wave.WaveFormat.CreateIeeeFloatWaveFormat(this.loopbackWaveIn.WaveFormat.SampleRate, this.loopbackWaveIn.WaveFormat.Channels)));
+            SetVolume(SWYH.Properties.Settings.Default.Volume, SWYH.Properties.Settings.Default.Mute);
 
             // Convert Raw Wav to PCM with audio format in settings
             var audioFormat = AudioSettings.GetAudioFormat();
@@ -116,6 +118,10 @@ namespace SWYH.Audio
             waveProcessorThread.Start();
         }
 
+        public void SetVolume(int volume, bool muted)
+        {
+            rawWave16b.Volume = muted ? 0 : (float)volume * 2 / 100;
+        }
 
         public void Dispose()
         {

--- a/SWYH/Properties/Settings.Designer.cs
+++ b/SWYH/Properties/Settings.Designer.cs
@@ -82,7 +82,37 @@ namespace SWYH.Properties {
                 this["AudioDevice"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
+        public int Volume
+        {
+            get
+            {
+                return ((int)(this["Volume"]));
+            }
+            set
+            {
+                this["Volume"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool Mute
+        {
+            get
+            {
+                return ((bool)(this["Mute"]));
+            }
+            set
+            {
+                this["Mute"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]

--- a/SWYH/SWYH.csproj
+++ b/SWYH/SWYH.csproj
@@ -127,6 +127,9 @@
     <Compile Include="UPnP\DvContentDirectory.cs" />
     <Compile Include="UPnP\DvX_MS_MediaReceiverRegistrar.cs" />
     <Compile Include="UPnP\SwyhDevice.cs" />
+    <Compile Include="Windows\Volume.xaml.cs">
+      <DependentUpon>Volume.xaml</DependentUpon>
+    </Compile>
     <Page Include="Windows\HTTPLiveStreamWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -148,6 +151,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Windows\RecordWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Windows\Volume.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/SWYH/Windows/Volume.xaml
+++ b/SWYH/Windows/Volume.xaml
@@ -1,0 +1,20 @@
+﻿<Window x:Class="SWYH.VolumeWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="" Loaded="Window_Loaded" Closing="Window_Closing" Deactivated="Window_Deactivated" KeyDown="Window_KeyDown"
+        Height="200" Width="70" ResizeMode="NoResize" ShowInTaskbar="False" Topmost="True" WindowStartupLocation="Manual"
+        WindowStyle="None" BorderThickness="2" BorderBrush="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
+    <Grid>
+        <Slider Name="slider1" Margin="10,10,20,10" Width="30" Height="150" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="20,10" Orientation="Vertical" TickPlacement="TopLeft" Maximum="200" AutoToolTipPlacement="BottomRight" ValueChanged="Slider_ValueChanged" TickFrequency="10" SmallChange="1" Value="50">
+            <Slider.RenderTransform>
+                <TransformGroup>
+                    <ScaleTransform ScaleX="1.5"/>
+                    <SkewTransform/>
+                    <RotateTransform/>
+                    <TranslateTransform/>
+                </TransformGroup>
+            </Slider.RenderTransform>
+        </Slider>
+        <CheckBox Name="checkBox1" Content="Mute" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="5,5,5,5" Checked="CheckBox_Checked" Unchecked="CheckBox_Unchecked"/>
+    </Grid>
+</Window>

--- a/SWYH/Windows/Volume.xaml.cs
+++ b/SWYH/Windows/Volume.xaml.cs
@@ -1,0 +1,108 @@
+﻿/*
+ *	 Stream What Your Hear
+ *	 Assembly: SWYH
+ *	 File: VolumeWindow.xaml.cs
+ *	 Web site: http://www.streamwhatyouhear.com
+ *	 Copyright (C) 2012-2019 - Sebastien Warin <http://sebastien.warin.fr> and others
+ *
+ *   This file is part of Stream What Your Hear.
+ *	 
+ *	 Stream What Your Hear is free software: you can redistribute it and/or modify
+ *	 it under the terms of the GNU General Public License as published by
+ *	 the Free Software Foundation, either version 2 of the License, or
+ *	 (at your option) any later version.
+ *	 
+ *	 Stream What Your Hear is distributed in the hope that it will be useful,
+ *	 but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	 GNU General Public License for more details.
+ *	 
+ *	 You should have received a copy of the GNU General Public License
+ *	 along with Stream What Your Hear. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace SWYH
+{
+    using System;
+    using System.Windows;
+
+    /// <summary>
+    /// Interaction logic for VolumeWindow.xaml
+    /// </summary>
+    public partial class VolumeWindow : Window
+    {
+        public VolumeWindow()
+        {
+            InitializeComponent();
+        }
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            this.slider1.Value = SWYH.Properties.Settings.Default.Volume;
+            this.checkBox1.IsChecked = SWYH.Properties.Settings.Default.Mute;
+        }
+
+        private void Window_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if (e.Key == System.Windows.Input.Key.Escape)
+            {
+                this.Close();
+            }
+        }
+
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            e.Cancel = true;
+
+            int volume = (int)this.slider1.Value;
+            if (SWYH.Properties.Settings.Default.Volume != volume ||
+                SWYH.Properties.Settings.Default.Mute != this.checkBox1.IsChecked)
+            {
+                SWYH.Properties.Settings.Default.Volume = volume;
+                SWYH.Properties.Settings.Default.Mute = (bool)this.checkBox1.IsChecked;
+                SWYH.Properties.Settings.Default.Save();
+            }
+
+            this.Hide();
+        }
+
+        private void Window_Deactivated(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+
+        public void ShowWithPosition()
+        {
+            this.Show();
+            System.Drawing.Point point = System.Windows.Forms.Control.MousePosition;
+            var transform = PresentationSource.FromVisual(this).CompositionTarget.TransformFromDevice;
+            var mouse = transform.Transform(new System.Windows.Point(point.X, point.Y));
+            Left = mouse.X - ActualWidth;
+            Top = mouse.Y - ActualHeight;
+            this.Activate();
+        }
+
+        private void Slider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (App.CurrentInstance.wasapiProvider != null)
+            {
+                App.CurrentInstance.wasapiProvider.SetVolume((int)e.NewValue, (bool)this.checkBox1.IsChecked);
+            }
+        }
+
+        private void CheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            if (App.CurrentInstance.wasapiProvider != null)
+            {
+                App.CurrentInstance.wasapiProvider.SetVolume((int)this.slider1.Value, true);
+            }
+        }
+
+        private void CheckBox_Unchecked(object sender, RoutedEventArgs e)
+        {
+            if (App.CurrentInstance.wasapiProvider != null)
+            {
+                App.CurrentInstance.wasapiProvider.SetVolume((int)this.slider1.Value, false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added volume control by left click on icon in system tray.

I have same discussable opinion.

As usual volume value 1 is 100%, but SWYH quieter then other programs.
And as I hear value 2 is equal to other my devices and programs as 100%.

Value 1 was by default and for back compartibility current volume is same with 50% volume.
My formula of volume value: `% * 2 / 100`.

Feel free check it and change volume value calculation if you need.